### PR TITLE
Add config for servers and protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,30 @@ Use SRV records for Elasticsearch discovery, like the ones
 
 ## Configuration
 
-```
+Key|Example|Description
+---|---|---
+`discovery.srv.query`|`elasticsearch-9300.service.consul`|The query string to use when querying for SRV records.
+`discovery.srv.servers`|`127.0.0.1:8600`|DNS Servers to contact. Can be an array or a comma-delimited string. Port numbers are optional.
+`discovery.srv.protocol`|`tcp`|Which protocol to use. Options are `tcp` and `udp`. Default is `tcp`.
+
+Note: Consul will return maximum 3 records when using UDP queries. All records are returned when using TCP.
+
+### Simple Example
+```yaml
 discovery:
   type: srv
   srv:
-    query: elasticsearch-transport.service.consul
+    query: elasticsearch-9300.service.consul
+```
+
+### Complex Example
+```yaml
+discovery:
+  type: srv
+  srv:
+    query: elasticsearch-9300.service.consul
+    protocol: tcp
+    servers:
+      - 127.0.0.1:8600
+      - 192.168.1.1
 ```

--- a/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015 Grant Rodgers
+ * Copyright (c) 2015 Grant Rodgers.
+ * Portions copyright (c) 2015 Crate.IO.
  *
  *     Permission is hereby granted, free of charge, to any person obtaining
  *     a copy of this software and associated documentation files (the "Software"),
@@ -24,6 +25,7 @@ package org.elasticsearch.discovery.srv;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Lists;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -33,6 +35,7 @@ import org.elasticsearch.discovery.zen.ping.unicast.UnicastHostsProvider;
 import org.elasticsearch.transport.TransportService;
 import org.xbill.DNS.*;
 
+import java.net.UnknownHostException;
 import java.util.List;
 
 /**
@@ -40,11 +43,17 @@ import java.util.List;
  */
 public class SrvUnicastHostsProvider extends AbstractComponent implements UnicastHostsProvider {
 
+    public static final String DISCOVERY_SRV_QUERY = "discovery.srv.query";
+    public static final String DISCOVERY_SRV_SERVERS = "discovery.srv.servers";
+
+    public static final String DISCOVERY_SRV_PROTOCOL = "discovery.srv.protocol";
+
     private final TransportService transportService;
 
     private final Version version;
 
     private final String query;
+    private final Resolver resolver;
 
     @Inject
     public SrvUnicastHostsProvider(Settings settings, TransportService transportService, Version version) {
@@ -52,46 +61,109 @@ public class SrvUnicastHostsProvider extends AbstractComponent implements Unicas
         this.transportService = transportService;
         this.version = version;
 
-        this.query = settings.get("discovery.srv.query");
+        this.query = settings.get(DISCOVERY_SRV_QUERY);
+        this.resolver = buildResolver(settings);
     }
 
-    @Override
-    public List<DiscoveryNode> buildDynamicNodes() {
-        List<DiscoveryNode> discoNodes = Lists.newArrayList();
+    @Nullable
+    private Resolver buildResolver(Settings settings) {
+        String[] addresses = settings.getAsArray(DISCOVERY_SRV_SERVERS);
 
-        try {
-            Record[] records = new Lookup(query, Type.SRV).run();
+        // Use tcp by default since it retrieves all records
+        String protocol = settings.get(DISCOVERY_SRV_PROTOCOL, "tcp");
 
-            logger.trace("building dynamic unicast discovery nodes...");
-            if (records == null) {
-                logger.debug("No nodes found");
-            } else {
-                for (Record record : records) {
-                    SRVRecord srv = (SRVRecord) record;
+        List<Resolver> resolvers = Lists.newArrayList();
 
-                    String hostname = srv.getTarget().toString().replaceFirst("\\.$", "");
-                    int port = srv.getPort();
-                    String address = hostname + ":" + port;
+        Resolver parent_resolver = null;
 
+        for (String address : addresses) {
+            String host = null;
+            int port = -1;
+            String[] parts = address.split(":");
+            if (parts.length > 0) {
+                host = parts[0];
+                if (parts.length > 1) {
                     try {
-                        TransportAddress[] addresses = transportService.addressesFromString(address);
-                        logger.trace("adding {}, transport_address {}", address, addresses[0]);
-                        discoNodes.add(new DiscoveryNode("#srv-" + address, addresses[0], version.minimumCompatibilityVersion()));
+                        port = Integer.valueOf(parts[1]);
                     } catch (Exception e) {
-                        logger.warn("failed to add {}, address {}", e, address);
+                        logger.warn("Resolver port '{}' is not an integer. Using default port 53", parts[1]);
                     }
                 }
+
             }
 
-
-        } catch (TextParseException e) {
-            logger.warn("Unable to parse DNS query '{}'", query);
-            logger.debug("DNS lookup exception:", e);
+            try {
+                Resolver resolver = new SimpleResolver(host);
+                if (port > 0) {
+                    resolver.setPort(port);
+                }
+                resolvers.add(resolver);
+            } catch (UnknownHostException e) {
+                logger.warn("Could not create resolver for '{}'", address, e);
+            }
         }
 
+        if (resolvers.size() > 0) {
+            try {
+                parent_resolver = new ExtendedResolver(resolvers.toArray(new Resolver[resolvers.size()]));
 
-        logger.debug("using dynamic discovery nodes {}", discoNodes);
+                if (protocol == "tcp") {
+                    parent_resolver.setTCP(true);
+                }
+            } catch (UnknownHostException e) {
+                logger.warn("Could not create resolver. Using default resolver.", e);
+            }
+        }
+        return parent_resolver;
+    }
 
+    public List<DiscoveryNode> buildDynamicNodes() {
+        List<DiscoveryNode> discoNodes = Lists.newArrayList();
+        if (query == null) {
+            logger.error("DNS query must not be null. Please set '{}'", DISCOVERY_SRV_QUERY);
+            return discoNodes;
+        }
+        try {
+            Record[] records = lookupRecords();
+            logger.trace("Building dynamic unicast discovery nodes...");
+            if (records == null || records.length == 0) {
+                logger.debug("No nodes found");
+            } else {
+                discoNodes = parseRecords(records);
+            }
+        } catch (TextParseException e) {
+            logger.error("Unable to parse DNS query '{}'", query);
+            logger.error("DNS lookup exception:", e);
+        }
+        logger.info("Using dynamic discovery nodes {}", discoNodes);
+        return discoNodes;
+    }
+
+    protected Record[] lookupRecords() throws TextParseException {
+        Lookup lookup = new Lookup(query, Type.SRV);
+        if (this.resolver != null) {
+            lookup.setResolver(this.resolver);
+        }
+        return lookup.run();
+    }
+
+    protected List<DiscoveryNode> parseRecords(Record[] records) {
+        List<DiscoveryNode> discoNodes = Lists.newArrayList();
+        for (Record record : records) {
+            SRVRecord srv = (SRVRecord) record;
+
+            String hostname = srv.getTarget().toString().replaceFirst("\\.$", "");
+            int port = srv.getPort();
+            String address = hostname + ":" + port;
+
+            try {
+                TransportAddress[] addresses = transportService.addressesFromString(address);
+                logger.trace("adding {}, transport_address {}", address, addresses[0]);
+                discoNodes.add(new DiscoveryNode("#srv-" + address, addresses[0], version.minimumCompatibilityVersion()));
+            } catch (Exception e) {
+                logger.warn("failed to add {}, address {}", e, address);
+            }
+        }
         return discoNodes;
     }
 }


### PR DESCRIPTION
Adds `discovery.srv.servers` to specifying DNS servers to contact and `discovery.srv.protocol` to specify TCP or UDP queries.

TCP is the default since Consul only returns 3 records when querying via UDP.
