### PR TITLE
Add plugin-descriptor.properties for ES 2.0

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -1,0 +1,7 @@
+classname=org.elasticsearch.plugin.discovery.SrvDiscoveryPlugin
+name=srv-discovery
+jvm=true
+java.version=${java.specification.version}
+description=${project.description}
+version=${project.version}
+elasticsearch.version=2.0.0-beta1

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </scm>
 
     <properties>
-        <elasticsearch.version>1.5.2</elasticsearch.version>
+        <elasticsearch.version>2.0.0-beta1</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -23,4 +23,13 @@
             </includes>
         </dependencySet>
     </dependencySets>
+    <fileSets>
+        <fileSet>
+            <outputDirectory>/</outputDirectory>
+            <directory>${project.basedir}</directory>
+            <includes>
+                <include>plugin-descriptor.properties</include>
+            </includes>
+        </fileSet>
+    </fileSets>
 </assembly>                                                     ˜


### PR DESCRIPTION
This adds the required `plugin-descriptor.properties` file to the root directory (see https://www.elastic.co/guide/en/elasticsearch/plugins/2.0/plugin-authors.html#_plugin_descriptor_file) for compatibility with ES 2.0.

There is no need to merge this in right away because it would be good to first have a system (most likely branches) in place for distributing a version of this plugin for each version of ES.
