### PR TITLE
Prepare 1.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,31 @@ Use SRV records for Elasticsearch discovery, like the ones
 Looking for a plugin that uses the Consul API directly? Check out
 [lithiumtech/elasticsearch-consul-discovery](https://github.com/lithiumtech/elasticsearch-consul-discovery).
 
+## Installation
+
+Based on the version of Elasticsearch that you're running, pick the compatible plugin version (e.g. `1.5.0`), then run this command:
+
+```bash
+bin/plugin install srv-discovery --url https://github.com/github/elasticsearch-srv-discovery/releases/download/1.5.0/elasticsearch-srv-discovery-1.5.0.zip
+```
+
+## Compatibility
+
+The SRV Discovery plugin is known to be compatible with these versions of Elasticsearch:
+
+Elasticsearch|SRV Discovery plugin
+-|-
+1.7.3|1.5.0
+1.7.2|1.5.0
+1.7.1|1.5.0
+1.7.0|1.5.0
+1.6.2|1.5.0
+1.6.1|1.5.0
+1.6.0|1.5.0
+1.5.2|1.5.0
+1.5.1|1.5.0
+1.5.0|1.5.0
+
 ## Configuration
 
 Key|Example|Description

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
   <groupId>org.elasticsearch</groupId>
   <artifactId>elasticsearch-srv-discovery</artifactId>
-  <version>1.5.2</version>
+  <version>1.5.0</version>
   <packaging>jar</packaging>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <elasticsearch.version>1.5.2</elasticsearch.version>
+    <elasticsearch.version>1.5.0</elasticsearch.version>
     <lucene.version>4.10.4</lucene.version>
   </properties>
 


### PR DESCRIPTION
According to the tests, this plugin is compatible with Elasticsearch versions `1.5.0` to `1.7.3`. I also confirmed that it works with `1.5.2` and `1.7.3` using real instances of Elasticsearch and Consul for DNS.

**Versioning strategy**: the plugin version will match the lowest compatible ES version. Since this plugin would require changes to be compatible with ES `1.4.5`, I chose `1.5.0` for the initial release. If we make the plugin compatible with `1.4.0` to `1.4.5`, a new plugin version `1.4.0` will be created. For ES `2.0.0`+, the major and minor versions will be locked to ES, and the patch version will be incremented in case ES breaks the plugin API in a patch release.

I decided against using [`release.py`](https://github.com/elastic/elasticsearch-plugins-script) for now because it seems to require some kind of [Sonatype account](http://central.sonatype.org/pages/ossrh-guide.html). Maybe it's something to look into in the future, though.

/cc @github/search
