### PR TITLE
Add test with 5 nodes to ensure TCP is working

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/srvtest/Constants.java
+++ b/src/main/java/org/elasticsearch/discovery/srvtest/Constants.java
@@ -26,4 +26,7 @@ public class Constants {
     public static final String TEST_QUERY = "test-tag.test-service.service.test.";
     public static final int NODE_0_TRANSPORT_TCP_PORT = 9300;
     public static final int NODE_1_TRANSPORT_TCP_PORT = 9301;
+    public static final int NODE_2_TRANSPORT_TCP_PORT = 9302;
+    public static final int NODE_3_TRANSPORT_TCP_PORT = 9303;
+    public static final int NODE_4_TRANSPORT_TCP_PORT = 9304;
 }

--- a/src/main/java/org/elasticsearch/discovery/srvtest/SrvtestUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srvtest/SrvtestUnicastHostsProvider.java
@@ -58,6 +58,9 @@ public class SrvtestUnicastHostsProvider extends SrvUnicastHostsProvider {
 
                         result.addRecord(new SRVRecord(query.getQuestion().getName(), DClass.IN, 1, 1, 1, Constants.NODE_0_TRANSPORT_TCP_PORT, Name.fromString(HOSTNAME)), Section.ANSWER);
                         result.addRecord(new SRVRecord(query.getQuestion().getName(), DClass.IN, 1, 1, 1, Constants.NODE_1_TRANSPORT_TCP_PORT, Name.fromString(HOSTNAME)), Section.ANSWER);
+                        result.addRecord(new SRVRecord(query.getQuestion().getName(), DClass.IN, 1, 1, 1, Constants.NODE_2_TRANSPORT_TCP_PORT, Name.fromString(HOSTNAME)), Section.ANSWER);
+                        result.addRecord(new SRVRecord(query.getQuestion().getName(), DClass.IN, 1, 1, 1, Constants.NODE_3_TRANSPORT_TCP_PORT, Name.fromString(HOSTNAME)), Section.ANSWER);
+                        result.addRecord(new SRVRecord(query.getQuestion().getName(), DClass.IN, 1, 1, 1, Constants.NODE_4_TRANSPORT_TCP_PORT, Name.fromString(HOSTNAME)), Section.ANSWER);
                         return result;
                     }
 

--- a/src/test/java/org/elasticsearch/discovery/srv/SrvDiscoveryIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/discovery/srv/SrvDiscoveryIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 @ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 0)
 public class SrvDiscoveryIntegrationTest extends ElasticsearchIntegrationTest {
     @Test
-    public void testClusterSrvDiscovery() throws Exception {
+    public void testClusterSrvDiscoveryWith2Nodes() throws Exception {
         ImmutableSettings.Builder b = settingsBuilder()
             .put("node.mode", "network")
             .put("discovery.zen.ping.multicast.enabled", "false")
@@ -46,5 +46,24 @@ public class SrvDiscoveryIntegrationTest extends ElasticsearchIntegrationTest {
         internalCluster().startNode(b.put("transport.tcp.port", String.valueOf(Constants.NODE_1_TRANSPORT_TCP_PORT)).build());
 
         assertEquals(cluster().size(), 2);
+    }
+
+    @Test
+    public void testClusterSrvDiscoveryWith5Nodes() throws Exception {
+        ImmutableSettings.Builder b = settingsBuilder()
+            .put("node.mode", "network")
+            .put("discovery.zen.ping.multicast.enabled", "false")
+            .put("discovery.type", "srvtest")
+            .put(SrvUnicastHostsProvider.DISCOVERY_SRV_QUERY, Constants.TEST_QUERY);
+
+        assertEquals(cluster().size(), 0);
+
+        internalCluster().startNode(b.put("transport.tcp.port", String.valueOf(Constants.NODE_0_TRANSPORT_TCP_PORT)).build());
+        internalCluster().startNode(b.put("transport.tcp.port", String.valueOf(Constants.NODE_1_TRANSPORT_TCP_PORT)).build());
+        internalCluster().startNode(b.put("transport.tcp.port", String.valueOf(Constants.NODE_2_TRANSPORT_TCP_PORT)).build());
+        internalCluster().startNode(b.put("transport.tcp.port", String.valueOf(Constants.NODE_3_TRANSPORT_TCP_PORT)).build());
+        internalCluster().startNode(b.put("transport.tcp.port", String.valueOf(Constants.NODE_4_TRANSPORT_TCP_PORT)).build());
+
+        assertEquals(cluster().size(), 5);
     }
 }


### PR DESCRIPTION
This tests a 5 node cluster to make sure TCP queries are working (the UDP limit is 3).

/cc @grantr
