### PR TITLE
Initialize list of resolvers with a default resolver

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
@@ -66,6 +66,7 @@ public class SrvUnicastHostsProvider extends AbstractComponent implements Unicas
         this.version = version;
 
         this.query = settings.get(DISCOVERY_SRV_QUERY);
+        logger.debug("Using query {}", this.query);
         this.resolver = buildResolver(settings);
     }
 

--- a/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Lists;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.discovery.zen.ping.unicast.UnicastHostsProvider;
@@ -67,11 +66,11 @@ public class SrvUnicastHostsProvider extends AbstractComponent implements Unicas
         this.version = version;
 
         this.query = settings.get(DISCOVERY_SRV_QUERY);
-        this.resolver = buildResolver(settings, logger);
+        this.resolver = buildResolver(settings);
     }
 
     @Nullable
-    protected Resolver buildResolver(Settings settings, ESLogger logger) {
+    protected Resolver buildResolver(Settings settings) {
         String[] addresses = settings.getAsArray(DISCOVERY_SRV_SERVERS);
 
         // Use tcp by default since it retrieves all records

--- a/src/main/java/org/elasticsearch/discovery/srvtest/SrvtestUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srvtest/SrvtestUnicastHostsProvider.java
@@ -25,6 +25,7 @@ package org.elasticsearch.discovery.srvtest;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.srv.SrvUnicastHostsProvider;
 import org.elasticsearch.transport.TransportService;
@@ -41,7 +42,7 @@ public class SrvtestUnicastHostsProvider extends SrvUnicastHostsProvider {
     }
 
     @Override
-    protected Resolver buildResolver(Settings settings) {
+    protected Resolver buildResolver(Settings settings, ESLogger logger) {
         try {
             return new SimpleResolver() {
                 @Override

--- a/src/main/java/org/elasticsearch/discovery/srvtest/SrvtestUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srvtest/SrvtestUnicastHostsProvider.java
@@ -25,7 +25,6 @@ package org.elasticsearch.discovery.srvtest;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.srv.SrvUnicastHostsProvider;
 import org.elasticsearch.transport.TransportService;
@@ -42,7 +41,7 @@ public class SrvtestUnicastHostsProvider extends SrvUnicastHostsProvider {
     }
 
     @Override
-    protected Resolver buildResolver(Settings settings, ESLogger logger) {
+    protected Resolver buildResolver(Settings settings) {
         try {
             return new SimpleResolver() {
                 @Override

--- a/src/test/java/org/elasticsearch/discovery/srv/SrvDiscoveryIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/discovery/srv/SrvDiscoveryIntegrationTest.java
@@ -27,6 +27,7 @@ import org.elasticsearch.discovery.srvtest.Constants;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.junit.Test;
+import org.xbill.DNS.Resolver;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 
@@ -65,5 +66,18 @@ public class SrvDiscoveryIntegrationTest extends ElasticsearchIntegrationTest {
         internalCluster().startNode(b.put("transport.tcp.port", String.valueOf(Constants.NODE_4_TRANSPORT_TCP_PORT)).build());
 
         assertEquals(cluster().size(), 5);
+    }
+
+    @Test
+    public void testResolverStillDefaultsToTcpWhenNoServersAreGiven() throws Exception {
+        ImmutableSettings.Builder b = settingsBuilder()
+            .put("node.mode", "network")
+            .put("discovery.zen.ping.multicast.enabled", "false")
+            .put("discovery.type", "srv")
+            .put(SrvUnicastHostsProvider.DISCOVERY_SRV_QUERY, "");
+
+        SrvUnicastHostsProvider provider = new SrvUnicastHostsProvider(b.build(), null, null);
+
+        assertTrue(provider.usingTCP);
     }
 }


### PR DESCRIPTION
This ensures that the protocol defaults to TCP even when no servers are specified.

/cc @grantr @hcguersoy
