### PR TITLE
Fix setting the TCP protocol

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/srv/SrvUnicastHostsProvider.java
@@ -109,7 +109,7 @@ public class SrvUnicastHostsProvider extends AbstractComponent implements Unicas
             try {
                 parent_resolver = new ExtendedResolver(resolvers.toArray(new Resolver[resolvers.size()]));
 
-                if (protocol == "tcp") {
+                if (protocol.equals("tcp")) {
                     parent_resolver.setTCP(true);
                 }
             } catch (UnknownHostException e) {


### PR DESCRIPTION
`==` was mistakenly used instead of `.equals` for string equality, which was causing the protocol to remain as UDP no matter the value of `discovery.srv.protocol`.

Fixes #11.

/cc @hcguersoy @grantr
