### PR TITLE
add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
Enables travis builds. The default command for maven is `mvn test`, for gradle it's `gradle check`.

Includes the gradle cache fix from https://docs.travis-ci.com/user/languages/java#Caching.

/cc @chrismwendt
