### PR TITLE
Prepare for release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 1.5.1 (2015-12-07)
+- Fix bug where TCP protocol was never set
+- Fix bug where protocol defaulted to UDP when no servers were specified
+
+## 1.5.0 (2015-11-17)
+- Release first version

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Looking for a plugin that uses the Consul API directly? Check out
 
 ## Installation
 
-Based on the version of Elasticsearch that you're running, pick the compatible plugin version (e.g. `1.5.0`), then run this command:
+Based on the version of Elasticsearch that you're running, pick the compatible plugin version (e.g. `1.5.1`), then run this command:
 
 ```bash
-bin/plugin install srv-discovery --url https://github.com/github/elasticsearch-srv-discovery/releases/download/1.5.0/elasticsearch-srv-discovery-1.5.0.zip
+bin/plugin install srv-discovery --url https://github.com/github/elasticsearch-srv-discovery/releases/download/1.5.1/elasticsearch-srv-discovery-1.5.1.zip
 ```
 
 Verify that the plugin was installed:
@@ -33,16 +33,16 @@ The SRV Discovery plugin is known to be compatible with these versions of Elasti
 
 Elasticsearch|SRV Discovery plugin
 ---|---
-1.7.3|1.5.0
-1.7.2|1.5.0
-1.7.1|1.5.0
-1.7.0|1.5.0
-1.6.2|1.5.0
-1.6.1|1.5.0
-1.6.0|1.5.0
-1.5.2|1.5.0
-1.5.1|1.5.0
-1.5.0|1.5.0
+1.7.3|1.5.1
+1.7.2|1.5.1
+1.7.1|1.5.1
+1.7.0|1.5.1
+1.6.2|1.5.1
+1.6.1|1.5.1
+1.6.0|1.5.1
+1.5.2|1.5.1
+1.5.1|1.5.1
+1.5.0|1.5.1
 
 ## Configuration
 


### PR DESCRIPTION
This adds the CHANGELOG and bumps all references of 1.5.0 to 1.5.1, except for the version in `build.gradle`.
