### PR TITLE
Disable Travis CI email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+notifications:
+  email: false


### PR DESCRIPTION
I prefer not to receive a bunch of emails from Travis CI when I can view the PR for builds that I'm interested in. Since this change affects collaborators, I want to make sure this is a shared preference.
